### PR TITLE
'.tar' was missing from the tarball's url

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,6 +5,6 @@ default['mosh']['install_type'] = case node['platform']
                                     "package"
                                   end
 default['mosh']['version'] = "1.1.3"
-default['mosh']['source_url'] = "https://github.com/downloads/keithw/mosh/mosh-#{node['mosh']['version']}.gz"
+default['mosh']['source_url'] = "https://github.com/downloads/keithw/mosh/mosh-#{node['mosh']['version']}.tar.gz"
 default['mosh']['source_checksum'] = "53234667e53625791ca43ced1ec43834cbd86a019c67ce5e4bd65556113c6eee"
 default['mosh']['configure_flags'] = []


### PR DESCRIPTION
`remote_file` resource couldn't get the tarball because the _.tar_ was missing.
