### PR TITLE
Moved up the bash resource so it's found

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -20,12 +20,6 @@
 build_dir = "#{Chef::Config[:file_cache_path]}/mosh-source"
 version = node['mosh']['version']
 
-remote_file "#{Chef::Config[:file_cache_path]}/mosh-#{version}.tar.gz" do
-  source node['mosh']['source_url']
-  checksum node['mosh']['source_checksum']
-  notifies :run, resources(:bash => "build-mosh"), :immediately
-end
-
 bash "build-mosh" do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
@@ -34,5 +28,12 @@ tar -zxvf mosh-#{version}.tar.gz
 (cd mosh-#{version} && make)
 (cd mosh-#{version} && make install)
 EOH
+  action :nothing
   not_if "mosh -v | head -1 | grep -qx 'mosh #{version}'"
+end
+
+remote_file "#{Chef::Config[:file_cache_path]}/mosh-#{version}.tar.gz" do
+  source node['mosh']['source_url']
+  checksum node['mosh']['source_checksum']
+  notifies :run, resources(:bash => "build-mosh"), :immediately
 end


### PR DESCRIPTION
This fix the error commented at the issue #4

It seems that the `bash` resource ned to be before, but I set its action to `:nothing` to avoid to be run before to be notified.
