### PR TITLE
Add 'apt' cookbook as a depends

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,3 +8,5 @@ version          "0.1.0"
 %w{ debian ubuntu mac_os_x mac_os_x_server redhat centos scientific amazon fedora gentoo arch }.each do |os|
   supports os
 end
+
+depends "apt"


### PR DESCRIPTION
The `recipes/package.rb` uses the cookbook so it need to be defined as a depend at the `metadata.rb` file.
