### PR TITLE
Add package depends for building the sources

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,3 +8,9 @@ default['mosh']['version'] = "1.1.3"
 default['mosh']['source_url'] = "https://github.com/downloads/keithw/mosh/mosh-#{node['mosh']['version']}.gz"
 default['mosh']['source_checksum'] = "53234667e53625791ca43ced1ec43834cbd86a019c67ce5e4bd65556113c6eee"
 default['mosh']['configure_flags'] = []
+default['mosh']['source_depends'] = case node['platform']
+                                    when 'ubuntu', 'debian'
+                                      %w{ protobuf-compiler libprotobuf-dev libboost-dev libutempter-dev libncurses5-dev zlib1g-dev }
+                                    else
+                                      []
+                                    end

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -20,6 +20,12 @@
 build_dir = "#{Chef::Config[:file_cache_path]}/mosh-source"
 version = node['mosh']['version']
 
+include_recipe "apt" if platform?("debian","ubuntu")
+
+node['mosh']['source_depends'].each do |pkg|
+  package pkg
+end
+
 remote_file "#{Chef::Config[:file_cache_path]}/mosh-#{version}.tar.gz" do
   source node['mosh']['source_url']
   checksum node['mosh']['source_checksum']


### PR DESCRIPTION
I've added the packages the mosh's documentation said were needed to biuld it from the sources.

I just added for Ubuntu and Debian (by now), but for the rest can be easily added at the `attributes/default.rb` file.

I've tested with Ubuntu Lucid and the packages seems to be the right ones, but there code doesn't build because the path `$BOOST_ROOT` seems to be bad, but that is another bug...

I hope this help.
Cheers
