### PR TITLE
Added libssl-dev and pkg-config to debian build dependencies.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -5,7 +5,7 @@ default['mosh']['source_checksum'] = "53234667e53625791ca43ced1ec43834cbd86a019c
 default['mosh']['configure_flags'] = []
 default['mosh']['source_depends'] = case node['platform']
                                     when 'ubuntu', 'debian'
-                                      %w{ protobuf-compiler libprotobuf-dev libboost-dev libutempter-dev libncurses5-dev zlib1g-dev }
+                                      %w{ protobuf-compiler libprotobuf-dev libboost-dev libutempter-dev libncurses5-dev zlib1g-dev libssl-dev pkg-config }
                                     when 'redhat', 'centos', 'oracle', 'scientific', 'amazon'
                                       %w{ protobuf-compiler protobuf-devel boost-devel libutempter-devel ncurses-devel zlib-devel }
                                     else


### PR DESCRIPTION
I tried to build mosh-1.2.4 on an almost-clean debian (squeeze) and ubuntu (trusty) hosts and the ./configure script failed because of lacking dependencies. This PR adds libssl-dev and pkg-config, so that the build can succeed.
