### PR TITLE
Prevent this cookbook from crashing Chef < 12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -14,6 +14,7 @@ depends 'yum'
 depends 'yum-epel'
 
 unless defined?(Ridley::Chef::Cookbook::Metadata)
-  source_url       'https://github.com/jtimberman/mosh-cookbook'
-  issues_url       'https://github.com/jtimberman/mosh-cookbook/issues'
+  # Prevent a crash when using this cookbook with Chef < 12
+  source_url 'https://github.com/jtimberman/mosh-cookbook'        if respond_to?(:source_url)
+  issues_url 'https://github.com/jtimberman/mosh-cookbook/issues' if respond_to?(:issues_url)
 end


### PR DESCRIPTION
It appears that it's the cookbook maintainers' responsibility to prevent new methods in metadata.rb to crash older versions of Chef (chef/chef#2937). This pull request fixes that crash.
