### PR TITLE
omit additional metadata attributes on Chef versions < 12

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -13,7 +13,7 @@ depends 'apt'
 depends 'yum'
 depends 'yum-epel'
 
-unless defined?(Ridley::Chef::Cookbook::Metadata)
+unless defined?(Ridley::Chef::Cookbook::Metadata) || Gem::Requirement.new('< 12').satisfied_by?(Gem::Version.new(Chef::VERSION))
   source_url       'https://github.com/jtimberman/mosh-cookbook'
   issues_url       'https://github.com/jtimberman/mosh-cookbook/issues'
 end


### PR DESCRIPTION
The presence of these new `source_url` and `issues_url` metadata attributes causes Chef 11 to explode and then I am sad.

There's another issue here which is that the metadata.json present in the v0.4.0 artifact on the supermarket site also contains these attributes, albeit with empty values. Not sure what we can do about that. Any thoughts?
